### PR TITLE
Add upcoming cli api support to editorconfig

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -171,7 +171,7 @@
     },
     {
       "description": "[EditorConfig](https://editorconfig.org/) implementation for Lite XL",
-      "version": "0.3",
+      "version": "0.4",
       "path": "plugins/editorconfig",
       "id": "editorconfig",
       "mod_version": "3.1"

--- a/plugins/editorconfig/runtest.lua
+++ b/plugins/editorconfig/runtest.lua
@@ -17,12 +17,14 @@ function core.log_quiet(format, ...)
   print(string.format(format, ...))
 end
 
--- check if --parsers flag was given to only output the path expressions and
--- their conversion into regular expressions.
-local PARSERS = false
-for _, argument in ipairs(ARGS) do
-  if argument == "--parsers" then
-    PARSERS = true
+-- if --parsers flag was not given run the full tests otherwise only output
+-- the path expressions and their conversion into regular expressions.
+local PARSERS = rawget(_G, "PARSERS") or false
+if MOD_VERSION_MAJOR == 3 and MOD_VERSION_MINOR < 2 then
+  for _, argument in ipairs(ARGS) do
+    if argument == "--parsers" then
+      PARSERS = true
+    end
   end
 end
 


### PR DESCRIPTION
As described on title this PR adds CLI API support to the editorconfig plugin.

![editorconfig-cli](https://github.com/pragtical/plugins/assets/1702572/f519f20e-15b4-4d44-90db-f1b1972bc690)
