### PR TITLE
Limit the current indentation highlight distance

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -590,7 +590,7 @@
       "id": "indentguide",
       "mod_version": "3",
       "path": "plugins/indentguide.lua",
-      "version": "0.2"
+      "version": "0.3"
     },
     {
       "description": "Production and Early-Access OpenJDK Builds, from Oracle.",


### PR DESCRIPTION
This change limits the calculation of active indentation guide line to prevent performance issues. The limit is configurable from the settings.

To reproduce:

1. open a file with ten of thousands of lines (eg: sqlite.c)
2. leave the cursor on the first line of the file
3. scroll to the end of the file

Without this change the docview will lag or become unresponsive.