### PR TITLE
Update link_opener to 0.1.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1726,8 +1726,8 @@
       "description": "Detects and underlines URLs in files, and enables a context menu entry and a hotkey to open them in the default browser.",
       "id": "link_opener",
       "mod_version": "3",
-      "remote": "https://github.com/irisdominguez/pragtical_link-opener_plugin:16fd1e95f559cf9bc326cd502442d1e33a5ada60",
-      "version": "0.1.0"
+      "remote": "https://github.com/irisdominguez/pragtical_link-opener_plugin:a0ddf285de7d1c10cf8c8859afb4d69fcc3c96a6",
+      "version": "0.1.1"
     },
     {
       "description": "Advanced linter with ErrorLens-like error reporting. Compatible with linters made for `linter` *([screenshot](https://raw.githubusercontent.com/liquid600pgm/lintplus/master/screenshots/1.png))*",


### PR DESCRIPTION
Updated with:
- Bug fix for windows users, that could not open links
- New functionality: context menu opens file under the click, instead of under the active cursor. Ctrl-Enter retains the previous functionality.