### PR TITLE
link-opener: Update version with some fixes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1784,8 +1784,8 @@
       "description": "Detects and underlines URLs in files, and enables a context menu entry and a hotkey to open them in the default browser.",
       "id": "link_opener",
       "mod_version": "3",
-      "remote": "https://github.com/irisdominguez/pragtical_link-opener_plugin:5cb47d7235f2ddb4c81dcb5b09b85b4a15b90778",
-      "version": "0.1.2"
+      "remote": "https://github.com/irisdominguez/pragtical_link-opener_plugin:6b68c43cf10cb44cc657b226ee0d8d22f987bc39",
+      "version": "0.1.3"
     },
     {
       "description": "Advanced linter with ErrorLens-like error reporting. Compatible with linters made for `linter` *([screenshot](https://raw.githubusercontent.com/liquid600pgm/lintplus/master/screenshots/1.png))*",


### PR DESCRIPTION
Another small update for link-opener, with changes by [jgmdev](https://github.com/jgmdev) and a small fix to avoid links getting split on Linux.

And I'll take the opportunity to say: Thanks for maintaining Pragtical, it's awesome ^_^