### PR TITLE
Use new common.open_in_system

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -513,7 +513,7 @@
       "id": "ghmarkdown",
       "mod_version": "3",
       "path": "plugins/ghmarkdown.lua",
-      "version": "0.3"
+      "version": "0.3.1"
     },
     {
       "description": "Shows \"git blame\" information of a line *([screenshot](https://raw.githubusercontent.com/juliardi/lite-xl-gitblame/main/screenshot_1.png))*",
@@ -2045,21 +2045,21 @@
       "id": "open_ext",
       "mod_version": "3",
       "path": "plugins/open_ext.lua",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "description": "Opens the parent directory of the current file in the file manager",
       "id": "openfilelocation",
       "mod_version": "3",
       "path": "plugins/openfilelocation.lua",
-      "version": "0.1"
+      "version": "0.1.1"
     },
     {
       "description": "Opens the selected filename or url",
       "id": "openselected",
       "mod_version": "3",
       "path": "plugins/openselected.lua",
-      "version": "0.1"
+      "version": "0.1.1"
     },
     {
       "description": "PDF preview for TeX files",
@@ -2349,7 +2349,7 @@
       "id": "updatechecker",
       "mod_version": "3",
       "path": "plugins/updatechecker.lua",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "description": "VI(vim?) bindings with a hint of DOOM Emacs, for pragtical",

--- a/plugins/ghmarkdown.lua
+++ b/plugins/ghmarkdown.lua
@@ -9,36 +9,21 @@ local common = require "core.common"
 
 
 config.plugins.ghmarkdown = common.merge({
-  -- string.format pattern to use for system.exec
-  exec_format = PLATFORM == "Windows" and "start %s" or "xdg-open %q",
   -- the url to send POST request to
   url = "https://api.github.com/markdown/raw",
+  -- Find information on how to generate your own token at
+  -- https://docs.github.com/en/rest/markdown/markdown?apiVersion=2022-11-28#render-a-markdown-document-in-raw-mode
+  github_token = "",
    -- The config specification used by the settings gui
   config_spec = {
     name = "Github Markdown Preview",
-    {
-      label = "Exec Pattern",
-      description = "The string.format() pattern to pass to system.exec.",
-      path = "exec_format",
-      type = "string",
-      default = PLATFORM == "Windows" and "start %s" or "xdg-open %q"
-    },
     {
       label = "URL",
       description = "The URL to POST the request to for formatting.",
       path = "url",
       type = "string",
       default = "https://api.github.com/markdown/raw"
-    }
-  }
-}, config.plugins.ghmarkdown)
-
-config.plugins.ghmarkdown = common.merge({
-  -- Find information on how to generate your own token at
-  -- https://docs.github.com/en/rest/markdown/markdown?apiVersion=2022-11-28#render-a-markdown-document-in-raw-mode
-  github_token = "",
-  config_spec = {
-    name = "GHMarkdown",
+    },
     {
       label = "GitHub token",
       description = "Enter your personal GitHub token",
@@ -48,6 +33,25 @@ config.plugins.ghmarkdown = common.merge({
     }
   }
 }, config.plugins.ghmarkdown)
+
+local open_link
+if common.open_in_system then
+  open_link = common.open_in_system
+else -- backward compatibility with older Pragtical versions
+  config.plugins.ghmarkdown.exec_format = PLATFORM == "Windows" and 'start "" %q' or "xdg-open %q"
+
+  table.insert(config.plugins.ghmarkdown, {
+    label = "Exec Pattern",
+    description = "The string.format() pattern to pass to system.exec.",
+    path = "exec_format",
+    type = "string",
+    default = PLATFORM == "Windows" and 'start "" %q' or "xdg-open %q"
+  })
+
+  open_link = function(file)
+    system.exec(string.format(config.plugins.ghmarkdown.exec_format, file))
+  end
+end
 
 local html = [[
 <html>
@@ -109,7 +113,7 @@ command.add("core.docview!", {
     fp:close()
 
     core.log("Opening markdown preview for \"%s\"", dv:get_name())
-    system.exec(string.format(config.plugins.ghmarkdown.exec_format, htmlfile))
+    open_link(htmlfile)
 
     core.add_thread(function()
       coroutine.yield(5)

--- a/plugins/open_ext.lua
+++ b/plugins/open_ext.lua
@@ -1,7 +1,7 @@
 -- mod-version:3
 
 -- The general idea is to check if the file opened is valid utf-8
--- since lite-xl only supports UTF8 text, others can be safely assumed
+-- since pragtical only supports UTF8 text, others can be safely assumed
 -- to be binary
 local core = require "core"
 local common = require "core.common"
@@ -43,13 +43,21 @@ end
 
 
 local msg = "This file is not displayed because it is either binary or uses an unsupported text encoding."
-local cmd -- here's evil code again...
-if PLATFORM == "Windows" then
-  cmd = "start %q"
-elseif PLATFORM == "Linux" then
-  cmd = "xdg-open %q"
-else
-  cmd = "open %q"
+
+local function open_external(resource)
+  if common.open_in_system then
+    common.open_in_system(resource)
+  else -- backward compatibility with older Pragtical versions
+    local cmd -- here's evil code again...
+    if PLATFORM == "Windows" then
+      cmd = 'start "" %q'
+    elseif PLATFORM == "Linux" then
+      cmd = "xdg-open %q"
+    else
+      cmd = "open %q"
+    end
+    system.exec(string.format(cmd, resource))
+  end
 end
 
 local opt = { "Open anyway", "Open with other program", "Close" }
@@ -63,7 +71,7 @@ local opt_actions = {
     -- open externally
     local node = core.root_view.root_node:get_node_for_view(self)
     node:close_view(core.root_view.root_node, self)
-    system.exec(string.format(cmd, self.filename))
+    open_external(self.filename)
   end,
   function(self)
     local node = core.root_view.root_node:get_node_for_view(self)

--- a/plugins/openselected.lua
+++ b/plugins/openselected.lua
@@ -6,30 +6,38 @@ local common = require "core.common"
 local config = require "core.config"
 local contextmenu = require "plugins.contextmenu"
 
+local open_external
+if common.open_in_system then
+  open_external = common.open_in_system
+else -- backward compatibility with older Pragtical versions
+  local platform_filelauncher
+  if PLATFORM == "Windows" then
+    platform_filelauncher = 'start ""'
+  elseif PLATFORM == "Mac OS X" then
+    platform_filelauncher = "open"
+  else
+    platform_filelauncher = "xdg-open"
+  end
 
-local platform_filelauncher
-if PLATFORM == "Windows" then
-  platform_filelauncher = "start"
-elseif PLATFORM == "Mac OS X" then
-  platform_filelauncher = "open"
-else
-  platform_filelauncher = "xdg-open"
-end
-
-config.plugins.openselected = common.merge({
-  filelauncher = platform_filelauncher,
-  -- The config specification used by the settings gui
-  config_spec = {
-    name = "Open Selected Text",
-    {
-      label = "File Launcher",
-      description = "Command used to open the selected path or link externally.",
-      path = "filelauncher",
-      type = "string",
-      default = platform_filelauncher
+  config.plugins.openselected = common.merge({
+    filelauncher = platform_filelauncher,
+    -- The config specification used by the settings gui
+    config_spec = {
+      name = "Open Selected Text",
+      {
+        label = "File Launcher",
+        description = "Command used to open the selected path or link externally.",
+        path = "filelauncher",
+        type = "string",
+        default = platform_filelauncher
+      }
     }
-  }
-}, config.plugins.openselected)
+  }, config.plugins.openselected)
+
+  open_external = function(text)
+    system.exec(config.plugins.openselected.filelauncher .. " " .. text)
+  end
+end
 
 command.add("core.docview!", {
   ["open-selected:open-selected"] = function(dv)
@@ -51,7 +59,7 @@ command.add("core.docview!", {
 
     core.log("Opening %s...", text)
 
-    system.exec(config.plugins.openselected.filelauncher .. " " .. text)
+    open_external(text)
   end,
 })
 
@@ -63,4 +71,3 @@ contextmenu:register("core.docview", {
 
 
 keymap.add { ["ctrl+alt+o"] = "open-selected:open-selected" }
-


### PR DESCRIPTION
This PR makes use of common.open_in_system on plugins that need to open a resource externally, it keeps backward compatibility with older versions of Pragtical. In the future, should clean-up the compatibility.

Needs pragtical/pragtical#321