### PR TITLE
fix: typo, use local path instead of remote

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -407,7 +407,7 @@
       "description": "Make sure the file ends with one blank line.",
       "id": "eofnewline",
       "mod_version": "3",
-      "url": "plugins/eofnewline.lua",
+      "path": "plugins/eofnewline.lua",
       "version": "0.1"
     },
     {


### PR DESCRIPTION
<img width="1250" height="238" alt="image" src="https://github.com/user-attachments/assets/487853a4-cfc9-4113-b07d-7d7b7d186a99" />
