### PR TITLE
link-opener: Fix url calling, add copy url functionality

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1795,8 +1795,8 @@
       "description": "Detects and underlines URLs in files, and enables a context menu entry and a hotkey to open them in the default browser.",
       "id": "link_opener",
       "mod_version": "3",
-      "remote": "https://github.com/irisdominguez/pragtical_link-opener_plugin:6b68c43cf10cb44cc657b226ee0d8d22f987bc39",
-      "version": "0.1.3"
+      "remote": "https://github.com/irisdominguez/pragtical_link-opener_plugin:20760da1fd9f677d87497b48e79a7b4b197bd370",
+      "version": "0.1.4"
     },
     {
       "description": "Advanced linter with ErrorLens-like error reporting. Compatible with linters made for `linter` *([screenshot](https://raw.githubusercontent.com/liquid600pgm/lintplus/master/screenshots/1.png))*",


### PR DESCRIPTION
- Fixes link opening in all systems by delegating to `common.open_in_system`
- Adds commands to copy urls to system clipboard 

Thanks to @2trvl for noticing the error and suggesting the fix 